### PR TITLE
Eigene Produkte können jetzt zu Mahlzeiten hinzugefügt werden

### DIFF
--- a/app/create-product.tsx
+++ b/app/create-product.tsx
@@ -14,7 +14,6 @@ export default function CreateProductScreen() {
   const [protein, setProtein] = useState('');
   const [carbs, setCarbs] = useState('');
   const [fat, setFat] = useState('');
-  const [portionWeight, setPortionWeight] = useState('');
 
   const canSave = name.trim().length > 0 && calories.trim().length > 0;
 
@@ -23,7 +22,7 @@ export default function CreateProductScreen() {
       barcode: `custom_${generateId()}`,
       name: name.trim(),
       brand: null,
-      quantity: portionWeight ? `${portionWeight}g` : null,
+      quantity: null,
       categories: [],
       imageUrl: null,
       imageThumbnailUrl: null,
@@ -43,7 +42,10 @@ export default function CreateProductScreen() {
       nutrientLevels: { fat: null, saturatedFat: null, sugars: null, salt: null },
     };
     await saveProduct(product);
-    router.back();
+    router.replace({
+      pathname: '/product-detail',
+      params: { barcode: product.barcode, productJson: JSON.stringify(product) },
+    });
   }
 
   return (
@@ -122,22 +124,6 @@ export default function CreateProductScreen() {
           </Surface>
         </Surface>
 
-        <Surface style={[styles.section, { backgroundColor: theme.colors.elevation.level2 }]} elevation={0}>
-          <Text variant="labelLarge" style={[styles.sectionTitle, { color: theme.colors.onBackground }]}>
-            STANDARD PORTION{' '}
-            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>(optional)</Text>
-          </Text>
-          <TextInput
-            label="Portion weight"
-            placeholder="e.g. 30"
-            value={portionWeight}
-            onChangeText={setPortionWeight}
-            keyboardType="numeric"
-            mode="outlined"
-            right={<TextInput.Affix text="G" />}
-            style={styles.input}
-          />
-        </Surface>
         <Button
           mode="contained"
           icon="content-save"

--- a/app/product-detail.tsx
+++ b/app/product-detail.tsx
@@ -5,7 +5,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { Product } from '@/models/product';
 import type { MealCategory } from '@/models/meal-entry';
-import { addMealItem, generateId } from '@/services/storage';
+import { addMealItem, saveProduct, generateId } from '@/services/storage';
 
 const MEAL_OPTIONS: { key: MealCategory; label: string; icon: string }[] = [
   { key: 'breakfast', label: 'BREAKFAST', icon: 'weather-sunset-up' },
@@ -140,6 +140,7 @@ export default function ProductDetailScreen() {
         mode="contained"
         icon="plus"
         onPress={async () => {
+          await saveProduct(product);
           await addMealItem(selectedMeal, {
             id: generateId(),
             name: product.name ?? 'Unbekannt',


### PR DESCRIPTION
## Summary
- Create-Product navigiert jetzt nach dem Speichern direkt zum Produktdetail-Bildschirm (gleicher Flow wie beim Scannen), wo Mahlzeit und Portion gewählt werden können
- Gescannte Produkte werden beim Hinzufügen zu einer Mahlzeit automatisch in AsyncStorage gespeichert
- Products-Tab bleibt unverändert (Platzhalter)

Closes #35