### PR TITLE
Produkt nur speichern, nicht direkt als Mahlzeit eintragen

### DIFF
--- a/app/create-product.tsx
+++ b/app/create-product.tsx
@@ -42,10 +42,7 @@ export default function CreateProductScreen() {
       nutrientLevels: { fat: null, saturatedFat: null, sugars: null, salt: null },
     };
     await saveProduct(product);
-    router.replace({
-      pathname: '/product-detail',
-      params: { barcode: product.barcode, productJson: JSON.stringify(product) },
-    });
+    router.back();
   }
 
   return (


### PR DESCRIPTION
## Summary
- Create-Product navigiert nach dem Speichern zurück statt zum Produktdetail-Bildschirm
- Das Produkt wird nur in der Datenbank gespeichert und kann danach über den Produkte-Tab einer Mahlzeit hinzugefügt werden

Closes #41