### PR TITLE
CI/CD Pipeline: APK automatisch bei Release bauen

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,63 @@
+name: Build Android APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate native project
+        run: npx expo prebuild --platform android --no-install
+
+      - name: Build APK
+        working-directory: android
+        run: ./gradlew assembleRelease
+
+      - name: Find APK
+        id: apk
+        run: |
+          APK_PATH=$(find android -name '*.apk' -path '*/release/*' | head -1)
+          echo "path=$APK_PATH" >> "$GITHUB_OUTPUT"
+          echo "Found APK at $APK_PATH"
+
+      - name: Get version from tag
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME:-${{ github.event.release.tag_name }}}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to existing release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "${{ steps.apk.outputs.path }}#Balori-${{ steps.version.outputs.tag }}.apk"
+
+      - name: Create release from tag
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            "${{ steps.apk.outputs.path }}#Balori-${{ steps.version.outputs.tag }}.apk" \
+            --title "Balori ${{ steps.version.outputs.tag }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
GitHub Actions Workflow das automatisch eine Android-APK baut wenn ein Git-Tag (v*) gepusht oder ein GitHub Release erstellt wird. Verwendet lokalen Gradle-Build (kein EAS nötig). Die APK wird automatisch an den Release angehängt.

Closes #49