### PR TITLE
Fix doppelte Pipeline-Runs bei Release

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,9 +1,6 @@
 name: Build Android APK
 
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [created]
 
@@ -42,22 +39,7 @@ jobs:
           echo "path=$APK_PATH" >> "$GITHUB_OUTPUT"
           echo "Found APK at $APK_PATH"
 
-      - name: Get version from tag
-        id: version
-        run: echo "tag=${GITHUB_REF_NAME:-${{ github.event.release.tag_name }}}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload to existing release
-        if: github.event_name == 'release'
+      - name: Upload APK to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name }}" "${{ steps.apk.outputs.path }}#Balori-${{ steps.version.outputs.tag }}.apk"
-
-      - name: Create release from tag
-        if: github.event_name == 'push'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            "${{ steps.apk.outputs.path }}#Balori-${{ steps.version.outputs.tag }}.apk" \
-            --title "Balori ${{ steps.version.outputs.tag }}" \
-            --generate-notes
+        run: gh release upload "${{ github.event.release.tag_name }}" "${{ steps.apk.outputs.path }}#Balori-${{ github.event.release.tag_name }}.apk"

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -11,9 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+      - uses: oven-sh/setup-bun@v2
 
       - uses: actions/setup-java@v4
         with:
@@ -23,10 +21,19 @@ jobs:
       - uses: android-actions/setup-android@v3
 
       - name: Install dependencies
-        run: npm install
+        run: bun install --frozen-lockfile
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
 
       - name: Generate native project
-        run: npx expo prebuild --platform android --no-install
+        run: bunx expo prebuild --platform android --no-install
 
       - name: Build APK
         working-directory: android
@@ -37,7 +44,6 @@ jobs:
         run: |
           APK_PATH=$(find android -name '*.apk' -path '*/release/*' | head -1)
           echo "path=$APK_PATH" >> "$GITHUB_OUTPUT"
-          echo "Found APK at $APK_PATH"
 
       - name: Upload APK to release
         env:


### PR DESCRIPTION
## Summary
Pipeline wird nur noch bei Release-Erstellung ausgelöst (nicht mehr zusätzlich bei Tag-Push), da beides gleichzeitig feuert und zu doppelten Runs führt.

Closes #49