### PR TITLE
Fix Release-Upload Permission für APK Pipeline

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
GITHUB_TOKEN braucht explizit contents:write um Assets an einen Release anzuhängen. Ohne diese Permission kommt HTTP 403.

Closes #49