### PR TITLE
Remove unused model properties and simplify API mapper

### DIFF
--- a/app/create-product.tsx
+++ b/app/create-product.tsx
@@ -22,24 +22,13 @@ export default function CreateProductScreen() {
       barcode: `custom_${generateId()}`,
       name: name.trim(),
       brand: null,
-      quantity: null,
-      categories: [],
       imageUrl: null,
-      imageThumbnailUrl: null,
       nutriments: {
         energyKcal100g: parseFloat(calories) || 0,
         proteins100g: parseFloat(protein) || null,
         carbohydrates100g: parseFloat(carbs) || null,
         fat100g: parseFloat(fat) || null,
-        saturatedFat100g: null,
-        sugars100g: null,
-        fiber100g: null,
-        salt100g: null,
-        sodium100g: null,
       },
-      nutriScore: null,
-      novaGroup: null,
-      nutrientLevels: { fat: null, saturatedFat: null, sugars: null, salt: null },
     };
     await saveProduct(product);
     router.back();

--- a/app/product-detail.tsx
+++ b/app/product-detail.tsx
@@ -144,7 +144,6 @@ export default function ProductDetailScreen() {
           await addMealItem(selectedMeal, {
             id: generateId(),
             name: product.name ?? 'Unbekannt',
-            barcode: product.barcode,
             amountGrams: portionGrams,
             kcal: Math.round((n.energyKcal100g ?? 0) * factor),
             protein: Math.round((n.proteins100g ?? 0) * factor),

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,4 +1,3 @@
 export type { Nutriments } from './nutriments';
-export type { NutrientLevels } from './nutrient-levels';
 export type { Product, ProductResult } from './product';
 export type { MealCategory, MealItem, DayLog, NutritionGoals } from './meal-entry';

--- a/models/meal-entry.ts
+++ b/models/meal-entry.ts
@@ -3,7 +3,6 @@ export type MealCategory = 'breakfast' | 'lunch' | 'dinner' | 'snack';
 export interface MealItem {
   id: string;
   name: string;
-  barcode: string | null;
   amountGrams: number;
   kcal: number;
   protein: number;

--- a/models/nutrient-levels.ts
+++ b/models/nutrient-levels.ts
@@ -1,6 +1,0 @@
-export interface NutrientLevels {
-  fat: string | null;
-  saturatedFat: string | null;
-  sugars: string | null;
-  salt: string | null;
-}

--- a/models/nutriments.ts
+++ b/models/nutriments.ts
@@ -3,9 +3,4 @@ export interface Nutriments {
   proteins100g: number | null;
   carbohydrates100g: number | null;
   fat100g: number | null;
-  saturatedFat100g: number | null;
-  sugars100g: number | null;
-  fiber100g: number | null;
-  salt100g: number | null;
-  sodium100g: number | null;
 }

--- a/models/product.ts
+++ b/models/product.ts
@@ -1,18 +1,11 @@
-import type { NutrientLevels } from './nutrient-levels';
 import type { Nutriments } from './nutriments';
 
 export interface Product {
   barcode: string;
   name: string | null;
   brand: string | null;
-  quantity: string | null;
-  categories: string[];
   imageUrl: string | null;
-  imageThumbnailUrl: string | null;
   nutriments: Nutriments;
-  nutriScore: string | null;
-  novaGroup: number | null;
-  nutrientLevels: NutrientLevels;
 }
 
 export interface ProductResult {

--- a/services/mappers.ts
+++ b/services/mappers.ts
@@ -1,0 +1,21 @@
+import type { Product } from '@/models/product';
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && !isNaN(value) ? value : null;
+}
+
+export function mapApiProduct(barcode: string, raw: Record<string, unknown>): Product {
+  const n = (raw.nutriments as Record<string, unknown>) ?? {};
+  return {
+    barcode,
+    name: (raw.product_name as string) || null,
+    brand: (raw.brands as string) || null,
+    imageUrl: (raw.image_front_url as string) || null,
+    nutriments: {
+      energyKcal100g: num(n['energy-kcal_100g']),
+      proteins100g: num(n.proteins_100g),
+      carbohydrates100g: num(n.carbohydrates_100g),
+      fat100g: num(n.fat_100g),
+    },
+  };
+}

--- a/services/open-food-facts.ts
+++ b/services/open-food-facts.ts
@@ -1,10 +1,7 @@
 import type { ProductResult } from '@/models/product';
+import { mapApiProduct } from './mappers';
 
 const BASE_URL = 'https://world.openfoodfacts.org/api/v2/product';
-
-function num(value: unknown): number | null {
-  return typeof value === 'number' && !isNaN(value) ? value : null;
-}
 
 export async function getProductByBarcode(barcode: string): Promise<ProductResult> {
   const url = `${BASE_URL}/${encodeURIComponent(barcode)}.json`;
@@ -20,40 +17,9 @@ export async function getProductByBarcode(barcode: string): Promise<ProductResul
     return { found: false, barcode, product: null };
   }
 
-  const raw = data.product;
-  const n = raw.nutriments ?? {};
-  const levels = raw.nutrient_levels ?? {};
-
   return {
     found: true,
     barcode,
-    product: {
-      barcode,
-      name: raw.product_name || null,
-      brand: raw.brands || null,
-      quantity: raw.quantity || null,
-      categories: raw.categories_tags ?? [],
-      imageUrl: raw.image_front_url || null,
-      imageThumbnailUrl: raw.image_front_small_url || null,
-      nutriments: {
-        energyKcal100g: num(n['energy-kcal_100g']),
-        proteins100g: num(n.proteins_100g),
-        carbohydrates100g: num(n.carbohydrates_100g),
-        fat100g: num(n.fat_100g),
-        saturatedFat100g: num(n['saturated-fat_100g']),
-        sugars100g: num(n.sugars_100g),
-        fiber100g: num(n.fiber_100g),
-        salt100g: num(n.salt_100g),
-        sodium100g: num(n.sodium_100g),
-      },
-      nutriScore: raw.nutriscore_grade || null,
-      novaGroup: num(raw.nova_group),
-      nutrientLevels: {
-        fat: levels.fat || null,
-        saturatedFat: levels['saturated-fat'] || null,
-        sugars: levels.sugars || null,
-        salt: levels.salt || null,
-      },
-    },
+    product: mapApiProduct(barcode, data.product),
   };
 }


### PR DESCRIPTION
## Summary
Remove 17 unused properties across Product, Nutriments, and MealItem. Delete the entire NutrientLevels interface and file. Extract API response mapping into services/mappers.ts. Simplify create-product.tsx and product-detail.tsx accordingly.

Closes #64