### PR TITLE
Simplify tabs layout with data-driven screen config

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,6 +3,13 @@ import { CommonActions } from '@react-navigation/native';
 import { Tabs } from 'expo-router';
 import { BottomNavigation } from 'react-native-paper';
 
+const TAB_SCREENS = [
+  { name: 'index', title: 'Fuel', icon: 'fire' },
+  { name: 'scan', title: 'Scan', icon: 'barcode-scan' },
+  { name: 'products', title: 'Products', icon: 'format-list-bulleted' },
+  { name: 'trend', title: 'Trend', icon: 'trending-up' },
+] as const;
+
 export default function TabLayout() {
   return (
     <Tabs
@@ -28,11 +35,7 @@ export default function TabLayout() {
             }
           }}
           renderIcon={({ route, focused, color }) =>
-            descriptors[route.key].options.tabBarIcon?.({
-              focused,
-              color,
-              size: 24,
-            }) ?? null
+            descriptors[route.key].options.tabBarIcon?.({ focused, color, size: 24 }) ?? null
           }
           getLabelText={({ route }) =>
             (descriptors[route.key].options.tabBarLabel as string) ??
@@ -41,42 +44,18 @@ export default function TabLayout() {
           }
         />
       )}>
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Fuel',
-          tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="fire" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="scan"
-        options={{
-          title: 'Scan',
-          tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="barcode-scan" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="products"
-        options={{
-          title: 'Products',
-          tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="format-list-bulleted" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="trend"
-        options={{
-          title: 'Trend',
-          tabBarIcon: ({ color, size }) => (
-            <MaterialCommunityIcons name="trending-up" size={size} color={color} />
-          ),
-        }}
-      />
+      {TAB_SCREENS.map(({ name, title, icon }) => (
+        <Tabs.Screen
+          key={name}
+          name={name}
+          options={{
+            title,
+            tabBarIcon: ({ color, size }) => (
+              <MaterialCommunityIcons name={icon} size={size} color={color} />
+            ),
+          }}
+        />
+      ))}
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
Define tab screens as a data array and loop over them instead of repeating four near-identical Tabs.Screen blocks. Same visual result, less repetition.

Closes #80