### PR TITLE
Remove unnecessary fallback logic from tabs layout

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -18,30 +18,16 @@ export default function TabLayout() {
         <BottomNavigation.Bar
           navigationState={state}
           safeAreaInsets={insets}
-          onTabPress={({ route, preventDefault }) => {
-            const event = navigation.emit({
-              type: 'tabPress',
-              target: route.key,
-              canPreventDefault: true,
+          onTabPress={({ route }) => {
+            navigation.dispatch({
+              ...CommonActions.navigate(route.name, route.params),
+              target: state.key,
             });
-
-            if (!event.defaultPrevented) {
-              navigation.dispatch({
-                ...CommonActions.navigate(route.name, route.params),
-                target: state.key,
-              });
-            } else {
-              preventDefault();
-            }
           }}
           renderIcon={({ route, focused, color }) =>
             descriptors[route.key].options.tabBarIcon?.({ focused, color, size: 24 }) ?? null
           }
-          getLabelText={({ route }) =>
-            (descriptors[route.key].options.tabBarLabel as string) ??
-            descriptors[route.key].options.title ??
-            route.name
-          }
+          getLabelText={({ route }) => descriptors[route.key].options.title!}
         />
       )}>
       {TAB_SCREENS.map(({ name, title, icon }) => (


### PR DESCRIPTION
## Summary
Simplify onTabPress by removing event listener validation that is never used. Simplify getLabelText by removing fallback chain — title is always defined in our config.

Closes #82