### PR TITLE
Remove redundant gesture handler import

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -11,7 +11,6 @@ import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
-import 'react-native-gesture-handler';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { PaperProvider } from 'react-native-paper';
 


### PR DESCRIPTION
## Summary
Remove side-effect import of react-native-gesture-handler — GestureHandlerRootView already handles the setup.

Closes #84