### PR TITLE
Add LearningView course documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ app-example
 
 # Playwright MCP
 .playwright-mcp/
+
+# LearningView course documents
+docs/learningview/files/
+docs/learningview/*.json

--- a/docs/learningview/course-overview.md
+++ b/docs/learningview/course-overview.md
@@ -1,0 +1,163 @@
+# M335 - Mobile-Applikation realisieren (LearnHub 25)
+
+## 1. CheckIn (11 tasks)
+
+### Goal 1: Modul 335
+- **Einführung Modul 335** — Handlungsziele, Leistungsbeurteilung, grober Ablauf
+- **Modulidentifikation** — PDF: m335-modulidentifikation.pdf, Link: Modulbaukasten
+- **Leistungsbeurteilung** — PDF: m335-leistungsbeurteilung.pdf, 3 Teile, Termine verbindlich
+- **Vorlage Projektdokumentation** — Leitfaden für LB 1 und 3
+- **Ablauf** — PDF: m335-ablauf.pdf, Termine LB 1-3 verbindlich
+- **Gruppenbildung LB** — Gruppen à 2-3 Personen
+
+### Goal 2: Hausregeln
+- **Hausordnung / Kursregeln** — PDF: ICT_LearnHub_Hausordnung.pdf
+- **Notfall-Reglement** — Verhalten im Notfall
+
+### Goal 3: Diverses
+- **Symbole in LearningView** — PDF: LearningView_RasterTN.pdf
+- **LernCoach Markus** — Markus Chiarot, Gründer App Castle GmbH, Frontend/Fullstack
+- **LernCoach Natalie** — Natalie Schumacher, Backend-Entwicklerin
+
+---
+
+## 2. App Entwicklung Grundlagen (14 tasks)
+
+### Goal 1: Entwicklungssysteme und Frameworks
+- **Entwicklungssysteme** — PDF: Übersicht Entwicklungssysteme, Diagramm Technologien
+- **Frameworks** — Recherche: Kotlin, Swift, React Native, Flutter etc.
+- **Entwicklungssysteme (Quiz 7/7)** — Frameworks in Kategorien zuordnen
+
+### Goal 2: Geräte, Auflösung und Bildschirmausrichtung
+- **Bildschirm Technik** — PDF: m335-bildschirmtechnik.pdf
+- **Bildschirmausrichtung** — PDF: m335-bildschirmausrichtungen.pdf
+- **Bedienung** — PDF: m335-bedienung.pdf
+- **Im Detail** — PDF: Think big, but build small.pdf
+- **Geräte Quiz (6/7)**
+
+### Goal 3: Sensoren und Aktoren
+- **Sensoren und Aktoren** — PDF: m335-sensoren-aktoren.pdf
+
+### Goal 4: Persistenz
+- **Persistenz** — PDF: m335-persistenz.pdf
+
+### Goal 5: Publishing und Stores
+- **Publishing** — PDF: m335-publishing.pdf (McCarthys 4 Ps)
+- **Publishing (Aufgabe)** — Untersuchung einer App (Product, Price, Place, Promotion)
+- **App Stores** — PDF: m335-app-stores.pdf
+- **App Stores (Aufgabe)** — Vergleich Google Play vs iOS App Store
+
+---
+
+## 3. Konzeption (13 tasks)
+
+### Goal 1: Die Idee
+- **Ziel** — PDF: m335-problem-ziele.pdf, Personas, Problemlösung
+- **Use Cases** — PDF: m335-use-cases.pdf
+- **User Stories** — PDF: m335-user-stories.pdf, DoD
+- **Im Detail** — PDF: KonzeptionUndIdeeEinerApp.pdf
+- **Konzept** — Aufgabe: Geschenke-App Konzept
+
+### Goal 2: UI/UX
+- **Guidelines und ISO** — PDF: m335-design-guidelines.pdf, m335-ISO EN-9241-110.pdf
+- **Navigation und Screens** — PDF: m335-navigation.pdf, m335-screens.pdf
+- **Im Detail** — PDF: UsabilityUndUser Experience.pdf
+- **UI/UX (Quiz)**
+
+### Goal 3: Visuelle Konzeption
+- **Wireframes, Mockup und Co** — PDF: m335-wireframes-mockup-storyboard.pdf
+- **Wireframe und Mockup Tools** — Balsamiq, Figma, Adobe XD, Marvel
+- **Im Detail** — PDF: VomPapierZumPrototyp.pdf
+- **Storyboard** — Aufgabe: Geschenke-App Storyboard
+
+---
+
+## 4. LB 1 — Konzeption (2 tasks)
+
+### Goal 1: LB 1
+- **Abgabe LB1 - Konzeption** — Konzept der App, Abgabe bis Ende Tag 2
+- **Reflexion zur Idee** — Fragen zur Reflexion der App-Idee
+
+---
+
+## 5. React Native (20 tasks)
+
+### Goal 1: Setup
+- **Projektumgebung einrichten** — NodeJS, Editor, Expo Go, Tunneling, GitHub Codespaces
+- **Default Projekt erkunden** — Standardprojekt starten, Files verstehen
+- **Eigenes Projekt erstellen** — 3 Möglichkeiten
+- **Projektarbeit** — Fragen in Projektgruppe klären
+
+### Goal 2: Navigation
+- **Expo Routing** — File-based routing
+- **React Navigation** — Library für Navigation
+- **Navigation** — Projektgruppe: Navigation klären
+
+### Goal 3: Libraries und Components
+- **Using Libraries** — Wie Libraries verwendet werden
+- **Core Components and APIs** — Built-in React Native Components
+- **Expo SDK** — Sensoren, Aktoren (Kamera, GPS etc.)
+- **UI Libs** — UI Component Libraries (React Native Paper etc.)
+- **Store Data** — Daten speichern in Expo
+- **React Native Directory** — Searchable library database
+- **Libraries wählen** — Dokumentieren welche Libraries verwendet werden
+
+### Goal 4: Production build und deployment
+- **EAS build und deploy** — APK/AAB erstellen, deployment
+- **EAS** — EAS Account erstellen, production build, APK installieren
+
+### Goal 5: Tutorials und Guides
+- **React Native** — Getting Started
+- **React Fundamentals** — React Grundlagen
+- **Expo** — Expo SDK Tutorial
+- **EAS** — CI/CD Pipeline Tutorial
+
+---
+
+## 6. Testing (5 tasks)
+
+### Goal 1: Testing Grundlagen
+- **Testing** — PDF: Testlandschaft, verschiedene Testverfahren
+- **Testing in React Native** — Unit Tests, Integration Tests
+
+### Goal 2: Unit Testing
+- **Expo Unit Testing** — Jest, Expo Unit Testing Guide
+- **Komponente testen** — Min. 2 Unit Tests + 1 Snapshot Test pro Person
+
+### Goal 3: E2E Testing
+- **E2E Testkonzept** — Testobjekt, Testumgebungen, Testfälle
+
+---
+
+## 7. LB 2 — Fachgespräch (1 task)
+
+### Goal 1: LB 2
+- **Themen** — Aufbau/Architektur, Features, Libraries, Testing etc.
+
+---
+
+## 8. LB 3 — Projekt (4 tasks)
+
+### Goal 1: Abgaben
+- **Pitch** — Endprodukt präsentieren
+- **Source Code** — .zip Datei (ohne node_modules)
+
+### Goal 2: Deliverables
+- **APK** — Production .apk Datei
+- **Projektdokumentation** — .pdf, Inhalte aus CheckIn > Leistungsbeurteilung
+
+---
+
+## Zusammenfassung
+
+| Topic | Tasks | Status |
+|-------|-------|--------|
+| CheckIn | 11 | Einstieg erledigt |
+| App Entwicklung Grundlagen | 14 | Theorie |
+| Konzeption | 13 | Theorie + Übungen |
+| LB 1 — Konzeption | 2 | Abgabe |
+| React Native | 20 | Praxis + Projekt |
+| Testing | 5 | Tests schreiben |
+| LB 2 — Fachgespräch | 1 | Mündlich |
+| LB 3 — Projekt | 4 | Finale Abgaben |
+| **Total** | **70** | |

--- a/docs/learningview/external-links.md
+++ b/docs/learningview/external-links.md
@@ -1,0 +1,29 @@
+# External Links from M335 Course
+
+## React Native / Expo
+- [Using Libraries](https://docs.expo.dev/workflow/using-libraries/)
+- [Core Components and APIs](https://reactnative.dev/docs/components-and-apis)
+- [Expo SDK Reference](https://docs.expo.dev/versions/latest/)
+- [Expo UI](https://docs.expo.dev/versions/latest/sdk/ui/)
+- [Store Data](https://docs.expo.dev/develop/user-interface/store-data/)
+- [React Native Directory](https://reactnative.directory/)
+- [React Native Getting Started](https://reactnative.dev/docs/getting-started)
+- [React Fundamentals](https://reactnative.dev/docs/intro-react)
+- [Expo Tutorial](https://docs.expo.dev/tutorial/introduction/)
+- [EAS Tutorial](https://docs.expo.dev/tutorial/eas/introduction/)
+
+## Testing
+- [Testing Overview (React Native)](https://reactnative.dev/docs/testing-overview)
+- [Unit Testing with Jest (Expo)](https://docs.expo.dev/develop/unit-testing/)
+
+## Tools (link attachments, not downloaded)
+- Modulbaukasten (link in Modulidentifikation task)
+- Verhalten bei Evakuation (link in Notfall-Reglement task)
+- Auswahl Technologie (image in Entwicklungssysteme task)
+- Testlandschaft (image in Testing task)
+- Balsamiq, Figma, Adobe XD, Marvel (links in Wireframe und Mockup Tools task)
+- Expo Get Started, Tools (links in Projektumgebung einrichten task)
+- File structure, Features (links in Default Projekt erkunden task)
+- File-based routing, Dynamic routes, Navigation patterns, Expo Router Details (links in Expo Routing task)
+- React Native Paper, gluestack-ui, React Native Elements, Tamagui, UI Kitten (links in UI Libs task)
+- Expo Unit Testing, Jest React Native Docs (links in Expo Unit Testing task)

--- a/docs/learningview/gap-analysis.md
+++ b/docs/learningview/gap-analysis.md
@@ -1,0 +1,58 @@
+# Gap Analysis: M335 Course Requirements vs. Balori Codebase
+
+Focus on Topic 5 (React Native) and Topic 6 (Testing).
+
+---
+
+## Topic 5 — React Native
+
+### Already Covered
+
+| Requirement | Evidence |
+|---|---|
+| **Setup** (Node, Expo Go, GitHub) | Expo SDK 54 project, GitHub repo with CI workflow |
+| **File-based routing** (Expo Router) | `app/` directory with `(tabs)/_layout.tsx`, `(pages)/` group |
+| **React Navigation integration** | Tab bar uses `@react-navigation/native` CommonActions + `react-native-paper` BottomNavigation |
+| **Core Components & APIs** | ScrollView, View, Pressable, StyleSheet, Animated, useWindowDimensions throughout |
+| **Expo SDK sensors/actuators** | Camera via `expo-camera` (barcode scanning) |
+| **UI component library** | `react-native-paper` (Text, Button, Dialog, FAB, Card, Surface, Portal, etc.) |
+| **Data persistence** | `@react-native-async-storage/async-storage` in `services/storage.ts` |
+| **Third-party libraries** | `react-native-gesture-handler` (Swipeable), `react-native-safe-area-context`, `@expo/vector-icons` |
+| **Production build / EAS** | `.github/workflows/build-apk.yml` builds APK on release |
+
+### Gaps / Needs Work
+
+| Requirement | Status |
+|---|---|
+| **Library documentation** | Course asks to document which libraries are used and why. No such document exists in the repo. Needed for the project documentation (LB 3). |
+| **EAS account + deploy** | The CI builds via `expo-doctor` and EAS, but there is no evidence of a personal EAS account setup or an `eas.json` with a production profile for manual deploy. Verify this is in place. |
+
+---
+
+## Topic 6 — Testing
+
+### Already Covered
+
+Nothing. The project has **zero tests**. No Jest config, no `@testing-library/react-native`, no test files outside `node_modules/`.
+
+### Gaps (All Are Blockers)
+
+| Requirement | What Is Needed |
+|---|---|
+| **Jest setup** | Install `jest`, `jest-expo`, `@testing-library/react-native`. Add Jest config to `package.json` or `jest.config.js`. |
+| **Unit tests (min. 2 per person)** | Good candidates: `mappers/product-mapper.ts` (pure function, easy to unit-test), `services/storage.ts` (mock AsyncStorage), helper logic like `computeStreak` in `trend.tsx` (extract and test). |
+| **Snapshot test (min. 1 per person)** | Good candidates: `ProgressCircle`, `MealCard`, `Calendar` -- small presentational components. |
+| **E2E test concept** | Course requires a written E2E test concept (test object, environments, test cases) -- not necessarily executed code, but the document must exist for LB 3. |
+
+---
+
+## Summary
+
+Topic 5 is in strong shape -- the app uses Expo Router, react-native-paper, camera, AsyncStorage, gestures, and has a CI pipeline. The only minor gap is a library-choice document for the project documentation.
+
+Topic 6 is a complete gap. No testing infrastructure exists. Priority actions:
+
+1. Set up Jest + jest-expo + testing-library.
+2. Write unit tests for `product-mapper` and extracted pure functions.
+3. Write snapshot tests for at least one presentational component.
+4. Draft an E2E test concept document.

--- a/docs/learningview/requirements-summary.md
+++ b/docs/learningview/requirements-summary.md
@@ -1,0 +1,57 @@
+# M335 Requirements Summary
+
+## Grading Breakdown
+
+- **LB1 -- Konzeption:** 30%
+- **LB2 -- Fachgespraech:** 20%
+- **LB3 -- Projekt:** 50%
+
+Late submissions: **0.5 grade deduction**.
+
+## App Requirements (mandatory)
+
+- An input form
+- Data/settings persistence
+- 3--5 screens
+- One special feature using sensors/actuators (camera, images, audio, gyroscope, Bluetooth, etc.)
+- Topic is freely chosen
+
+## LB1 -- Konzeption (due 17:00 Tag 2)
+
+Submit the concept section of the project documentation containing:
+
+- Ausgangslage (initial situation)
+- Target group analysis with personas
+- Use cases with scenarios and a use case diagram
+- User stories with acceptance criteria per story
+- Mockups covering full app functionality
+- Description of the special feature (sensor/actuator usage)
+- Persistence strategy
+
+Heaviest-weighted criteria: mockups (x3), use cases (x2), special feature + persistence (x2).
+
+## LB2 -- Fachgespraech (Tag 4)
+
+Oral group exam moderated by the coach. Topics include app architecture, features, sensors/actuators, persistence, conception, and testing. Every member must participate. Criteria: answering questions convincingly (x3) and explaining code competently (x3).
+
+## LB3 -- Projekt (due 17:00 Tag 5, pitch at ~15:00 Tag 5)
+
+Deliverables:
+
+1. **Pitch** of the final product (goal, demo, reflection)
+2. **Source code** (.zip without node_modules)
+3. **Production APK**
+4. **Full project documentation** (PDF) containing: concept (from LB1), E2E test concept, implementation report (libraries chosen, deviations from concept, implementation notes), E2E test protocol, test conclusion (code coverage + E2E results)
+5. **Unit/snapshot tests** (min. 2 unit tests + 1 snapshot test per person)
+
+Heaviest-weighted criteria: professional code quality (x3), main features working (x3), stability (x2), I/O functions (x2), documentation (x2).
+
+## Timeline (5-day module)
+
+| Day | Focus |
+|-----|-------|
+| 1 | CheckIn, theory (dev basics, conception) |
+| 2 | Concept work, React Native intro, **LB1 due 17:00** |
+| 3 | Project work, testing theory, E2E test concept, unit tests |
+| 4 | Project work, unit/integration tests, **LB2 Fachgespraech** |
+| 5 | Finish project, test protocol, documentation, **pitch ~15:00**, **LB3 due 17:00** |


### PR DESCRIPTION
## Summary
Add M335 course structure docs scraped from LearningView: course overview (70 tasks across 8 topics), requirements summary (LB1/LB2/LB3 deliverables), gap analysis (what Balori covers vs what's missing), and external links. Gitignore downloaded PDFs and JSON artifacts.

Closes #92