### PR TITLE
Fix keyboard blocking macro inputs in dialogs

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "softwareKeyboardLayoutMode": "resize"
+      "softwareKeyboardLayoutMode": "pan"
     },
     "web": {
       "output": "static",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { PaperProvider } from 'react-native-paper';
 
 SplashScreen.preventAutoHideAsync();
@@ -46,6 +47,7 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
+      <KeyboardProvider>
       <PaperProvider theme={baloriTheme}>
         <ThemeProvider value={navigationTheme}>
           <Stack>
@@ -55,6 +57,7 @@ export default function RootLayout() {
           <StatusBar style="light" />
         </ThemeProvider>
       </PaperProvider>
+      </KeyboardProvider>
     </GestureHandlerRootView>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-keyboard-controller": "1.18.5",
         "react-native-paper": "^5.15.1",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -1568,6 +1569,8 @@
     "react-native-gesture-handler": ["react-native-gesture-handler@2.28.0", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
+
+    "react-native-keyboard-controller": ["react-native-keyboard-controller@1.18.5", "", { "dependencies": { "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-reanimated": ">=3.0.0" } }, "sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ=="],
 
     "react-native-paper": ["react-native-paper@5.15.1", "", { "dependencies": { "@callstack/react-theme-provider": "^3.0.9", "color": "^3.1.2", "use-latest-callback": "^0.2.3" }, "peerDependencies": { "react": "*", "react-native": "*", "react-native-safe-area-context": "*" } }, "sha512-qT3vtjWch7277JiyacOukPMmyJjgAeEXMZAl/1KdCFYGrarOVoVw5ElUcUCYwPdq9ReMyVZSX77Sr+7ELmSFEg=="],
 

--- a/dialogs/EditMealDialog.tsx
+++ b/dialogs/EditMealDialog.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { Keyboard, Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { Button, Dialog, Text, TextInput, useTheme } from 'react-native-paper';
 import { MacroInputRow } from '@/components/MacroInputRow';
 
@@ -27,9 +27,35 @@ export function EditMealDialog({
   onDismiss, onSave,
 }: EditMealDialogProps) {
   const theme = useTheme();
+  const [keyboardOffset, setKeyboardOffset] = useState(0);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardOffset(e.endCoordinates.height / 2);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardOffset(0);
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   return (
-    <Dialog visible={visible} onDismiss={onDismiss} style={{ backgroundColor: theme.colors.surface, maxHeight: '80%', top: -50 }}>
+    <Dialog
+      visible={visible}
+      onDismiss={onDismiss}
+      style={{
+        backgroundColor: theme.colors.surface,
+        maxHeight: '80%',
+        transform: [{ translateY: -keyboardOffset }],
+      }}
+    >
       <Dialog.Title>Eintrag bearbeiten</Dialog.Title>
       <Dialog.Content>
         <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">

--- a/dialogs/EditMealDialog.tsx
+++ b/dialogs/EditMealDialog.tsx
@@ -29,10 +29,10 @@ export function EditMealDialog({
   const theme = useTheme();
 
   return (
-    <Dialog visible={visible} onDismiss={onDismiss} style={{ backgroundColor: theme.colors.surface, maxHeight: '80%' }}>
+    <Dialog visible={visible} onDismiss={onDismiss} style={{ backgroundColor: theme.colors.surface, maxHeight: '80%', top: -50 }}>
       <Dialog.Title>Eintrag bearbeiten</Dialog.Title>
       <Dialog.Content>
-        <ScrollView showsVerticalScrollIndicator={false}>
+        <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
           <TextInput label="Name" value={name} onChangeText={onNameChange} mode="outlined" style={styles.inputSpacing} />
           <View style={styles.inputRow}>
             <TextInput label="Menge (g/ml)" value={amount} onChangeText={onAmountChange} keyboardType="numeric" mode="outlined" style={[styles.flex1, { marginRight: 4 }]} />

--- a/dialogs/ProductDialog.tsx
+++ b/dialogs/ProductDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import { Keyboard, Platform, ScrollView, StyleSheet } from 'react-native';
 import { Button, Dialog, Text, TextInput, useTheme } from 'react-native-paper';
 import { MacroInputRow } from '@/components/MacroInputRow';
 
@@ -27,6 +27,7 @@ export function ProductDialog({ visible, title, initial, onDismiss, onSave }: Pr
   const [protein, setProtein] = useState('');
   const [carbs, setCarbs] = useState('');
   const [fat, setFat] = useState('');
+  const [keyboardOffset, setKeyboardOffset] = useState(0);
 
   useEffect(() => {
     if (visible && initial) {
@@ -47,10 +48,35 @@ export function ProductDialog({ visible, title, initial, onDismiss, onSave }: Pr
     }
   }, [visible, initial]);
 
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardOffset(e.endCoordinates.height / 2);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardOffset(0);
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
   const canSave = name.trim().length > 0;
 
   return (
-    <Dialog visible={visible} onDismiss={onDismiss} style={{ backgroundColor: theme.colors.surface, maxHeight: '85%', top: -50 }}>
+    <Dialog
+      visible={visible}
+      onDismiss={onDismiss}
+      style={{
+        backgroundColor: theme.colors.surface,
+        maxHeight: '85%',
+        transform: [{ translateY: -keyboardOffset }],
+      }}
+    >
       <Dialog.Title>{title}</Dialog.Title>
       <Dialog.Content>
         <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">

--- a/dialogs/ProductDialog.tsx
+++ b/dialogs/ProductDialog.tsx
@@ -50,10 +50,10 @@ export function ProductDialog({ visible, title, initial, onDismiss, onSave }: Pr
   const canSave = name.trim().length > 0;
 
   return (
-    <Dialog visible={visible} onDismiss={onDismiss} style={{ backgroundColor: theme.colors.surface, maxHeight: '85%' }}>
+    <Dialog visible={visible} onDismiss={onDismiss} style={{ backgroundColor: theme.colors.surface, maxHeight: '85%', top: -50 }}>
       <Dialog.Title>{title}</Dialog.Title>
       <Dialog.Content>
-        <ScrollView showsVerticalScrollIndicator={false}>
+        <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
           <TextInput label="Name" value={name} onChangeText={setName} mode="outlined" style={styles.inputSpacing} />
           <TextInput label="Marke (optional)" value={brand} onChangeText={setBrand} mode="outlined" style={styles.inputSpacing} />
           <Text variant="labelLarge" style={{ marginTop: 8, marginBottom: 4, color: theme.colors.onSurfaceVariant }}>

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-paper": "^5.15.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
## Summary
Add KeyboardAvoidingView and keyboardShouldPersistTaps to ProductDialog and EditMealDialog so the keyboard does not cover the macro input fields.

Closes #98